### PR TITLE
Update index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -239,7 +239,7 @@ exports.reduce = function fastReduce (subject, fn, initialValue, thisContext) {
  * @param  {Object}   thisContext The context for the visitor.
  */
 exports.forEach = function fastForEach (subject, fn, thisContext) {
-  var keys = Object.keys(subject),
+  	var keys = Object.keys(subject);
 	var length = keys.length;
 	for (i = 0; i < length; i++) {
 		callback.call(thisContext, subject[keys[i]], keys[i], subject);


### PR DESCRIPTION
Array.forEach will only iterate over keys that exist. So for example, forEach will only iterate twice for `[0,,,,,5]`, on elements 0 and 5. Likewise, take 

```
var arr = [0,1,2]; 
delete arr[1]; 
arr.forEach(function(e){console.log(e);})
```

The console output will be 0 and 2.

If you were to check if a value is undefined, you run into the same problem because you can have an array element that exists with an undefined value. forEach should iterate over that, but not over a nonexistent element.

Using Object.keys solves this problem.
