### PR TITLE
add spidermonkey benchmark runner

### DIFF
--- a/bench/index-of-10.js
+++ b/bench/index-of-10.js
@@ -1,23 +1,22 @@
 var fast = require('../lib'),
+    history = require('../test/history'),
     underscore = require('underscore'),
     lodash = require('lodash');
 
 var input = [1,2,3,4,5,6,7,8,9,10];
 
-
 exports['Array::indexOf()'] = function () {
-  return input.indexOf(9);
+  return input.indexOf(9) + input.indexOf(Math.random());
 };
 
 exports['fast.indexOf()'] = function () {
-  return fast.indexOf(input, 9);
+  return fast.indexOf(input, 9) + fast.indexOf(input, Math.random());
 };
 
 exports['underscore.indexOf()'] = function () {
-  return underscore.indexOf(input, 9);
+  return underscore.indexOf(input, 9) + underscore.indexOf(input, Math.random());
 };
 
 exports['lodash.indexOf()'] = function () {
-  return lodash.indexOf(input, 9);
+  return lodash.indexOf(input, 9) + lodash.indexOf(input, Math.random());
 };
-

--- a/bench/index-of-1000.js
+++ b/bench/index-of-1000.js
@@ -1,4 +1,5 @@
 var fast = require('../lib'),
+    history = require('../test/history'),
     underscore = require('underscore'),
     lodash = require('lodash');
 
@@ -9,18 +10,19 @@ for (var i = 0; i < 1000; i++) {
 }
 
 exports['Array::indexOf()'] = function () {
-  return input.indexOf(1) + input.indexOf(999);
+  return input.indexOf(1) + input.indexOf(999) + input.indexOf(Math.random());
 };
 
 exports['fast.indexOf()'] = function () {
-  return fast.indexOf(input, 1) + fast.indexOf(input, 999);
+  return fast.indexOf(input, 1) + fast.indexOf(input, 999) + fast.indexOf(input, Math.random());
 };
 
 exports['underscore.indexOf()'] = function () {
-  return underscore.indexOf(input, 1) + fast.indexOf(input, 999);
+  return underscore.indexOf(input, 1) + underscore.indexOf(input, 999) + un
+  .indexOf(input, Math.random());
 };
 
 exports['lodash.indexOf()'] = function () {
-  return lodash.indexOf(input, 1) + fast.indexOf(input, 999);
+  return lodash.indexOf(input, 1) + lodash.indexOf(input, 999) + lodash.indexOf(input, Math.random());
 };
 

--- a/bench/index-of-3.js
+++ b/bench/index-of-3.js
@@ -1,21 +1,22 @@
 var fast = require('../lib'),
+    history = require('../test/history'),
     underscore = require('underscore'),
     lodash = require('lodash');
 
 var input = [1,2,3];
 
 exports['Array::indexOf()'] = function () {
-  return input.indexOf(3);
+  return input.indexOf(3) + input.indexOf(Math.random());
 };
 
 exports['fast.indexOf()'] = function () {
-  return fast.indexOf(input, 3);
+  return fast.indexOf(input, 3) + fast.indexOf(input, Math.random());
 };
 
 exports['underscore.indexOf()'] = function () {
-  return underscore.indexOf(3);
+  return underscore.indexOf(input, 3) + underscore.indexOf(input, Math.random());
 };
 
 exports['lodash.indexOf()'] = function () {
-  return lodash.indexOf(input, 3);
+  return lodash.indexOf(input, 3) + lodash.indexOf(input, Math.random());
 };

--- a/bench/index.js
+++ b/bench/index.js
@@ -2,14 +2,14 @@ var Benchmark = require('benchmark');
 
 run([
 
-  bench('Native .lastIndexOf() vs fast.lastIndexOf() (3 items)', require('./last-index-of-3')),
-  bench('Native .lastIndexOf() vs fast.lastIndexOf() (10 items)', require('./last-index-of-10')),
-  bench('Native .lastIndexOf() vs fast.lastIndexOf() (1000 items)', require('./last-index-of-1000')),
 
   bench('Native .indexOf() vs fast.indexOf() (3 items)', require('./index-of-3')),
   bench('Native .indexOf() vs fast.indexOf() (10 items)', require('./index-of-10')),
   bench('Native .indexOf() vs fast.indexOf() (1000 items)', require('./index-of-1000')),
 
+  bench('Native .lastIndexOf() vs fast.lastIndexOf() (3 items)', require('./last-index-of-3')),
+  bench('Native .lastIndexOf() vs fast.lastIndexOf() (10 items)', require('./last-index-of-10')),
+  bench('Native .lastIndexOf() vs fast.lastIndexOf() (1000 items)', require('./last-index-of-1000')),
   bench('Native .bind() vs fast.bind()', require('./bind')),
   bench('Native .bind() vs fast.bind() with prebound functions', require('./bind-prebound')),
 

--- a/ci/environments/sm/README.md
+++ b/ci/environments/sm/README.md
@@ -1,0 +1,3 @@
+# Spider Monkey
+
+This directory contains the spidermonkey js-shell. Run `npm run install-sm` to install it.

--- a/ci/sm-shim.js
+++ b/ci/sm-shim.js
@@ -1,0 +1,6 @@
+window = (function () { return this; })();
+console = {
+  log: typeof print === 'function' ? print : function () {}
+};
+
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,9 +4,9 @@
  * Internal helper to bind a function with a known arguments contract
  * to a given context
  *
- * fastBind(function(x) {return this[x];}, {foo: 1}, 1)
+ * bindInternal(function(x) {return this[x];}, {foo: 1}, 1)
  */
-function fastBind(func, thisContext, numArgs) {
+function bindInternal (func, thisContext, numArgs) {
   switch (numArgs) {
     case 3: return function(a, b, c) {
       return func.call(thisContext, a, b, c);
@@ -214,7 +214,7 @@ exports.map = function fastMap (subject, fn, thisContext) {
   var length = subject.length,
       result = new Array(length),
       i,
-      iterator = arguments.length > 2 ? fastBind(fn, thisContext, 3) : fn;
+      iterator = arguments.length > 2 ? bindInternal(fn, thisContext, 3) : fn;
   for (i = 0; i < length; i++) {
     result[i] = iterator(subject[i], i, subject);
   }
@@ -236,7 +236,7 @@ exports.reduce = function fastReduce (subject, fn, initialValue, thisContext) {
   var length = subject.length,
       result = initialValue,
       i,
-      iterator = arguments.length > 3 ? fastBind(fn, thisContext, 4) : fn;
+      iterator = arguments.length > 3 ? bindInternal(fn, thisContext, 4) : fn;
   for (i = 0; i < length; i++) {
     result = iterator(result, subject[i], i, subject);
   }
@@ -255,7 +255,7 @@ exports.reduce = function fastReduce (subject, fn, initialValue, thisContext) {
 exports.forEach = function fastForEach (subject, fn, thisContext) {
   var length = subject.length,
       i,
-      iterator = arguments.length > 2 ? fastBind(fn, thisContext, 3) : fn;
+      iterator = arguments.length > 2 ? bindInternal(fn, thisContext, 3) : fn;
   for (i = 0; i < length; i++) {
     iterator(subject[i], i, subject);
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "pretest": "npm run jshint",
     "test": "mocha",
     "bench": "node ./bench/index.js",
-    "coverage": "./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha"
+    "coverage": "./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha",
+    "install-sm": "wget http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-trunk/jsshell-linux-x86_64.zip -O ./ci/environments/sm/sm.zip; unzip -o -d ./ci/environments/sm ./ci/environments/sm/sm.zip",
+    "sm": "browserify ./bench/index.js | cat ./ci/sm-shim.js - > ./ci/environments/sm/bench.js; ./ci/environments/sm/js -f ./ci/environments/sm/bench.js"
   },
   "repository": {
     "type": "git",
@@ -33,6 +35,7 @@
     "istanbul": "~0.2.11",
     "jshint": "~2.5.1",
     "underscore": "^1.6.0",
-    "lodash": "^2.4.1"
+    "lodash": "^2.4.1",
+    "browserify": "~4.1.11"
   }
 }

--- a/test/history.js
+++ b/test/history.js
@@ -102,3 +102,30 @@ exports.forEach_0_0_0 = function fastForEach (subject, fn, thisContext) {
     fn.call(thisContext, subject[i], i, subject);
   }
 };
+
+
+
+// v0.0.1
+
+
+exports.indexOf_0_0_1 = function fastIndexOf (subject, target) {
+  var length = subject.length,
+      i;
+  for (i = 0; i < length; i++) {
+    if (subject[i] === target) {
+      return i;
+    }
+  }
+  return -1;
+};
+
+exports.lastIndexOf_0_0_1 = function fastLastIndexOf (subject, target) {
+  var length = subject.length,
+      i;
+  for (i = length - 1; i >= 0; i--) {
+    if (subject[i] === target) {
+      return i;
+    }
+  }
+  return -1;
+};


### PR DESCRIPTION
This adds two things:
1. Download the latest (linux x64) js-shell from mozilla.org:

```
npm run install-sm
```
1. Browserify the benchmarks, then run them in js-shell:

```
npm run sm
```
