### PR TITLE
add reduceRight()

### DIFF
--- a/bench/index.js
+++ b/bench/index.js
@@ -41,6 +41,10 @@ run([
   bench('Native .reduce() vs fast.reduce() (10 items)', require('./reduce-10')),
   bench('Native .reduce() vs fast.reduce() (1000 items)', require('./reduce-1000')),
 
+  bench('Native .reduceRight() vs fast.reduceRight() (3 items)', require('./reduce-right-3')),
+  bench('Native .reduceRight() vs fast.reduceRight() (10 items)', require('./reduce-right-10')),
+  bench('Native .reduceRight() vs fast.reduceRight() (1000 items)', require('./reduce-right-1000')),
+
   bench('Native .forEach() vs fast.forEach() (3 items)', require('./for-each-3')),
   bench('Native .forEach() vs fast.forEach() (10 items)', require('./for-each-10')),
   bench('Native .forEach() vs fast.forEach() (1000 items)', require('./for-each-1000')),

--- a/bench/reduce-right-10.js
+++ b/bench/reduce-right-10.js
@@ -1,0 +1,24 @@
+var fast = require('../lib'),
+    underscore = require('underscore'),
+    lodash = require('lodash'),
+    history = require('../test/history');
+
+var input = [1,2,3,4,5,6,7,8,9,10];
+var reducer = function (last, item) { return last + item + Math.random(); };
+
+
+exports['Array::reduceRight()'] = function () {
+  return input.reduceRight(reducer, 0);
+};
+
+exports['fast.reduceRight()'] = function () {
+  return fast.reduceRight(input, reducer, 0);
+};
+
+exports['underscore.reduceRight()'] = function () {
+  return underscore.reduceRight(input, reducer, 0);
+};
+
+exports['lodash.reduceRight()'] = function () {
+  return lodash.reduceRight(input, reducer, 0);
+};

--- a/bench/reduce-right-1000.js
+++ b/bench/reduce-right-1000.js
@@ -1,0 +1,28 @@
+var fast = require('../lib'),
+    underscore = require('underscore'),
+    lodash = require('lodash'),
+    history = require('../test/history');
+
+var input = [];
+
+for (var i = 0; i < 1000; i++) {
+  input.push(i);
+}
+var reducer = function (last, item) { return last + item + Math.random(); };
+
+
+exports['Array::reduceRight()'] = function () {
+  return input.reduceRight(reducer, 0);
+};
+
+exports['fast.reduceRight()'] = function () {
+  return fast.reduceRight(input, reducer, 0);
+};
+
+exports['underscore.reduceRight()'] = function () {
+  return underscore.reduceRight(input, reducer, 0);
+};
+
+exports['lodash.reduceRight()'] = function () {
+  return lodash.reduceRight(input, reducer, 0);
+};

--- a/bench/reduce-right-3.js
+++ b/bench/reduce-right-3.js
@@ -1,0 +1,24 @@
+var fast = require('../lib'),
+    underscore = require('underscore'),
+    lodash = require('lodash'),
+    history = require('../test/history');
+
+var input = [1,2,3];
+var reducer = function (last, item) { return last + item + Math.random(); };
+
+
+exports['Array::reduceRight()'] = function () {
+  return input.reduceRight(reducer, 0);
+};
+
+exports['fast.reduceRight()'] = function () {
+  return fast.reduceRight(input, reducer, 0);
+};
+
+exports['underscore.reduceRight()'] = function () {
+  return underscore.reduceRight(input, reducer, 0);
+};
+
+exports['lodash.reduceRight()'] = function () {
+  return lodash.reduceRight(input, reducer, 0);
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -301,6 +301,39 @@ exports.reduce = function fastReduce (subject, fn, initialValue, thisContext) {
 };
 
 /**
+ * # Reduce Right
+ *
+ * A fast `.reduceRight()` implementation.
+ *
+ * @param  {Array}    subject      The array (or array-like) to reduce.
+ * @param  {Function} fn           The reducer function.
+ * @param  {mixed}    initialValue The initial value for the reducer, defaults to subject[0].
+ * @param  {Object}   thisContext  The context for the reducer.
+ * @return {mixed}                 The final result.
+ */
+exports.reduceRight = function fastReduce (subject, fn, initialValue, thisContext) {
+  var length = subject.length,
+      iterator = thisContext !== undefined ? bindInternal4(fn, thisContext) : fn,
+      i, result;
+
+  if (initialValue === undefined) {
+    i = length - 2;
+    result = subject[length - 1];
+  }
+  else {
+    i = length - 1;
+    result = initialValue;
+  }
+
+  for (; i >= 0; i--) {
+    result = iterator(result, subject[i], i, subject);
+  }
+
+  return result;
+};
+
+
+/**
  * # For Each
  *
  * A fast `.forEach()` implementation.

--- a/test/test.js
+++ b/test/test.js
@@ -173,11 +173,33 @@ describe('fast.reduce()', function () {
       this.should.equal(fast);
     }, {}, fast);
   });
-  it('should use the input[0] if initialValue isn\'t provided', function() {
+  it('should use input[0] if initialValue isn\'t provided', function() {
     var result = fast.reduce(input, function (last, item) {
       return last + item;
     });
     result.should.equal(15);
+  });
+});
+
+describe('fast.reduceRight()', function () {
+  var input = ["a", "b", "c"];
+
+  it('should reduce a list of items', function () {
+    var result = fast.reduceRight(input, function (last, item) {
+      return last + item;
+    }, "z");
+    result.should.equal("zcba");
+  });
+  it('should take context', function () {
+    fast.reduceRight([1], function () {
+      this.should.equal(fast);
+    }, {}, fast);
+  });
+  it('should use input[input.length - 1] if initialValue isn\'t provided', function() {
+    var result = fast.reduceRight(input, function (last, item) {
+      return last + item;
+    });
+    result.should.equal("cba");
   });
 });
 


### PR DESCRIPTION
#### V8

```
  Native .reduceRight() vs fast.reduceRight() (3 items)
    ✓  Array::reduceRight() x 5,598,005 ops/sec ±2.14% (92 runs sampled)
    ✓  fast.reduceRight() x 15,059,446 ops/sec ±1.97% (90 runs sampled)
    ✓  underscore.reduceRight() x 4,013,166 ops/sec ±1.85% (88 runs sampled)
    ✓  lodash.reduceRight() x 4,112,906 ops/sec ±1.78% (91 runs sampled)

    Result: fast.js is 169.01% faster than Array::reduceRight().

  Native .reduceRight() vs fast.reduceRight() (10 items)
    ✓  Array::reduceRight() x 2,213,215 ops/sec ±1.92% (87 runs sampled)
    ✓  fast.reduceRight() x 6,042,686 ops/sec ±1.56% (95 runs sampled)
    ✓  underscore.reduceRight() x 1,965,478 ops/sec ±1.87% (89 runs sampled)
    ✓  lodash.reduceRight() x 2,468,101 ops/sec ±1.79% (80 runs sampled)

    Result: fast.js is 173.03% faster than Array::reduceRight().

  Native .reduceRight() vs fast.reduceRight() (1000 items)
    ✓  Array::reduceRight() x 28,038 ops/sec ±1.71% (87 runs sampled)
    ✓  fast.reduceRight() x 72,798 ops/sec ±1.65% (87 runs sampled)
    ✓  underscore.reduceRight() x 28,210 ops/sec ±1.48% (93 runs sampled)
    ✓  lodash.reduceRight() x 48,161 ops/sec ±1.35% (94 runs sampled)

    Result: fast.js is 159.64% faster than Array::reduceRight().

```
#### SpiderMonkey

```
  Native .reduceRight() vs fast.reduceRight() (3 items)
    ✓  Array::reduceRight() x 30,287,360 ops/sec ±0.22% (69 runs sampled)
    ✓  fast.reduceRight() x 32,876,772 ops/sec ±0.39% (68 runs sampled)
    ✓  underscore.reduceRight() x 1,287,249 ops/sec ±3.18% (62 runs sampled)
    ✓  lodash.reduceRight() x 6,765,882 ops/sec ±0.39% (68 runs sampled)

    Result: fast.js is 8.55% faster than Array::reduceRight().

  Native .reduceRight() vs fast.reduceRight() (10 items)
    ✓  Array::reduceRight() x 7,160,762 ops/sec ±0.46% (69 runs sampled)
    ✓  fast.reduceRight() x 7,381,591 ops/sec ±0.40% (67 runs sampled)
    ✓  underscore.reduceRight() x 1,134,680 ops/sec ±3.03% (60 runs sampled)
    ✓  lodash.reduceRight() x 3,072,712 ops/sec ±0.62% (69 runs sampled)

    Result: fast.js is 3.08% faster than Array::reduceRight().

  Native .reduceRight() vs fast.reduceRight() (1000 items)
    ✓  Array::reduceRight() x 70,336 ops/sec ±1.99% (65 runs sampled)
    ✓  fast.reduceRight() x 79,415 ops/sec ±0.34% (69 runs sampled)
    ✓  underscore.reduceRight() x 65,985 ops/sec ±2.21% (63 runs sampled)
    ✓  lodash.reduceRight() x 44,474 ops/sec ±1.53% (67 runs sampled)

    Result: fast.js is 12.91% faster than Array::reduceRight().

```
