### PR TITLE
Add fast.some()

### DIFF
--- a/bench/index.js
+++ b/bench/index.js
@@ -45,6 +45,10 @@ run([
   bench('Native .forEach() vs fast.forEach() (10 items)', require('./for-each-10')),
   bench('Native .forEach() vs fast.forEach() (1000 items)', require('./for-each-1000')),
 
+  bench('Native .some() vs fast.some() (3 items)', require('./some-3')),
+  bench('Native .some() vs fast.some() (10 items)', require('./some-10')),
+  bench('Native .some() vs fast.some() (1000 items)', require('./some-1000')),
+
   bench('Native .concat() vs fast.concat() (3 items)', require('./concat-3')),
   bench('Native .concat() vs fast.concat() (10 items)', require('./concat-10')),
   bench('Native .concat() vs fast.concat() (1000 items)', require('./concat-1000')),

--- a/bench/some-10.js
+++ b/bench/some-10.js
@@ -1,0 +1,24 @@
+var fast = require('../lib'),
+    underscore = require('underscore'),
+    lodash = require('lodash'),
+    history = require('../test/history');
+
+var input = [1,2,3,4,5,6,7,8,9,10];
+var check = function (item) { return item === 10; };
+
+
+exports['Array::some()'] = function () {
+  return input.some(check);
+};
+
+exports['fast.some()'] = function () {
+  return fast.some(input, check);
+};
+
+exports['underscore.some()'] = function () {
+  return underscore.some(input, check);
+};
+
+exports['lodash.some()'] = function () {
+  return lodash.some(input, check);
+};

--- a/bench/some-1000.js
+++ b/bench/some-1000.js
@@ -1,0 +1,28 @@
+var fast = require('../lib'),
+    underscore = require('underscore'),
+    lodash = require('lodash'),
+    history = require('../test/history');
+
+var input = [];
+
+for (var i = 0; i < 1000; i++) {
+  input.push(i);
+}
+var check = function (item) { return item === 999; };
+
+
+exports['Array::some()'] = function () {
+  return input.some(check);
+};
+
+exports['fast.some()'] = function () {
+  return fast.some(input, check);
+};
+
+exports['underscore.some()'] = function () {
+  return underscore.some(input, check);
+};
+
+exports['lodash.some()'] = function () {
+  return lodash.some(input, check);
+};

--- a/bench/some-3.js
+++ b/bench/some-3.js
@@ -1,0 +1,24 @@
+var fast = require('../lib'),
+    underscore = require('underscore'),
+    lodash = require('lodash'),
+    history = require('../test/history');
+
+var input = [1,2,3];
+var check = function (item) { return item === 3; };
+
+
+exports['Array::some()'] = function () {
+  return input.some(check);
+};
+
+exports['fast.some()'] = function () {
+  return fast.some(input, check);
+};
+
+exports['underscore.some()'] = function () {
+  return underscore.some(input, check);
+};
+
+exports['lodash.some()'] = function () {
+  return lodash.some(input, check);
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -237,8 +237,8 @@ exports.concat = function fastConcat () {
 exports.map = function fastMap (subject, fn, thisContext) {
   var length = subject.length,
       result = new Array(length),
-      i,
-      iterator = thisContext !== undefined ? bindInternal3(fn, thisContext) : fn;
+      iterator = thisContext !== undefined ? bindInternal3(fn, thisContext) : fn,
+      i;
   for (i = 0; i < length; i++) {
     result[i] = iterator(subject[i], i, subject);
   }
@@ -258,8 +258,8 @@ exports.map = function fastMap (subject, fn, thisContext) {
 exports.filter = function fastFilter (subject, fn, thisContext) {
   var length = subject.length,
       result = [],
-      i,
-      iterator = thisContext !== undefined ? bindInternal3(fn, thisContext) : fn;
+      iterator = thisContext !== undefined ? bindInternal3(fn, thisContext) : fn,
+      i;
   for (i = 0; i < length; i++) {
     if (iterator(subject[i], i, subject)) {
       result.push(subject[i]);
@@ -311,11 +311,33 @@ exports.reduce = function fastReduce (subject, fn, initialValue, thisContext) {
  */
 exports.forEach = function fastForEach (subject, fn, thisContext) {
   var length = subject.length,
-      i,
-      iterator = thisContext !== undefined ? bindInternal3(fn, thisContext) : fn;
+      iterator = thisContext !== undefined ? bindInternal3(fn, thisContext) : fn,
+      i;
   for (i = 0; i < length; i++) {
     iterator(subject[i], i, subject);
   }
+};
+
+/**
+ * # Some
+ *
+ * A fast `.some()` implementation.
+ *
+ * @param  {Array}    subject     The array (or array-like) to iterate over.
+ * @param  {Function} fn          The visitor function.
+ * @param  {Object}   thisContext The context for the visitor.
+ * @return {Boolean}              true if at least one item in the array passes the truth test.
+ */
+exports.some = function fastSome (subject, fn, thisContext) {
+  var length = subject.length,
+      iterator = thisContext !== undefined ? bindInternal3(fn, thisContext) : fn,
+      i;
+  for (i = 0; i < length; i++) {
+    if (iterator(subject[i], i, subject)) {
+      return true;
+    }
+  }
+  return false;
 };
 
 /**

--- a/test/test.js
+++ b/test/test.js
@@ -198,6 +198,29 @@ describe('fast.forEach()', function () {
   });
 });
 
+describe('fast.some()', function () {
+  var input = [1,2,3,4,5];
+
+  it('should return true if the check passes', function () {
+    var result = fast.some(input, function (item) {
+      return item === 3;
+    });
+    result.should.be.true;
+  });
+  it('should return false if the check fails', function () {
+    var result = fast.some(input, function (item) {
+      return item === 30000;
+    });
+    result.should.be.false;
+  });
+  it('should take context', function () {
+    fast.some([1], function () {
+      this.should.equal(fast);
+    }, fast);
+  });
+});
+
+
 describe('fast.indexOf()', function () {
   var input = [1,2,3,4,5];
   it('should return the index of the first item', function () {


### PR DESCRIPTION
#### V8

```
  Native .some() vs fast.some() (3 items)
    ✓  Array::some() x 6,552,463 ops/sec ±1.91% (85 runs sampled)
    ✓  fast.some() x 21,451,697 ops/sec ±1.54% (84 runs sampled)
    ✓  underscore.some() x 5,814,797 ops/sec ±1.48% (94 runs sampled)
    ✓  lodash.some() x 10,993,279 ops/sec ±1.78% (79 runs sampled)

    Result: fast.js is 227.38% faster than Array::some().

  Native .some() vs fast.some() (10 items)
    ✓  Array::some() x 2,759,374 ops/sec ±1.92% (91 runs sampled)
    ✓  fast.some() x 9,646,575 ops/sec ±1.61% (91 runs sampled)
    ✓  underscore.some() x 2,552,896 ops/sec ±2.34% (85 runs sampled)
    ✓  lodash.some() x 6,066,681 ops/sec ±1.87% (91 runs sampled)

    Result: fast.js is 249.59% faster than Array::some().

  Native .some() vs fast.some() (1000 items)
    ✓  Array::some() x 33,712 ops/sec ±2.09% (80 runs sampled)
    ✓  fast.some() x 127,554 ops/sec ±1.75% (95 runs sampled)
    ✓  underscore.some() x 33,080 ops/sec ±2.23% (86 runs sampled)
    ✓  lodash.some() x 108,813 ops/sec ±2.25% (92 runs sampled)

    Result: fast.js is 278.36% faster than Array::some().
```
#### SpiderMonkey

```
  Native .some() vs fast.some() (3 items)
    ✓  Array::some() x 71,218,274 ops/sec ±0.46% (69 runs sampled)
    ✓  fast.some() x 76,141,786 ops/sec ±0.56% (69 runs sampled)
    ✓  underscore.some() x 26,856,985 ops/sec ±0.44% (69 runs sampled)
    ✓  lodash.some() x 11,156,303 ops/sec ±1.71% (67 runs sampled)

    Result: fast.js is 6.91% faster than Array::some().

  Native .some() vs fast.some() (10 items)
    ✓  Array::some() x 11,811,974 ops/sec ±0.56% (69 runs sampled)
    ✓  fast.some() x 11,460,204 ops/sec ±1.41% (65 runs sampled)
    ✓  underscore.some() x 9,199,784 ops/sec ±2.30% (66 runs sampled)
    ✓  lodash.some() x 6,148,923 ops/sec ±0.39% (68 runs sampled)

    Result: fast.js is 2.98% slower than Array::some().

  Native .some() vs fast.some() (1000 items)
    ✓  Array::some() x 130,149 ops/sec ±0.25% (69 runs sampled)
    ✓  fast.some() x 132,925 ops/sec ±0.42% (68 runs sampled)
    ✓  underscore.some() x 126,776 ops/sec ±0.58% (69 runs sampled)
    ✓  lodash.some() x 107,808 ops/sec ±0.27% (63 runs sampled)

    Result: fast.js is 2.13% faster than Array::some().

```
