### PR TITLE
better/stricter fromIndex

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ By optimising for the 99% use case, fast.js methods can be up to 5x faster than 
 
 ## Caveats
 
-As mentioned above, fast.js does not conform 100% to the ECMAScript specification and is therefore not a drop in replacement 100% of the time. There are at least four scenarios where the behavior differs from the spec:
+As mentioned above, fast.js does not conform 100% to the ECMAScript specification and is therefore not a drop in replacement 100% of the time. There are at least three scenarios where the behavior differs from the spec:
 
 - Sparse arrays are not supported. A sparse array will be treated just like a normal array, with unpopulated slots containing `undefined` values. This means that iteration functions such as `.map()` and `.forEach()` will visit these empty slots, receiving `undefined` as an argument. This is in contrast to the native implementations where these unfilled slots will be skipped entirely by the iterators. In the real world, sparse arrays are very rare. This is evidenced by the very popular [underscore.js](http://underscorejs.org/)'s lack of support.
 
@@ -82,7 +82,6 @@ As mentioned above, fast.js does not conform 100% to the ECMAScript specificatio
 
     - A 4th argument is supported - `thisContext`, the context to bind the reducer function to. This is not present in the spec but is provided for convenience.
 
-- The `fromIndex` parameter for `fast.indexOf()` and `fast.lastIndexOf()` has a maximum useful value of `2147483647`. Values which exceed this will produce unexpected results.
 
 In practice, it's extremely unlikely that any of these caveats will have an impact on real world code. These constructs are extremely uncommon.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -410,8 +410,8 @@ exports.indexOf = function fastIndexOf (subject, target, fromIndex) {
   var length = subject.length,
       i = 0;
 
-  if (fromIndex !== undefined) {
-    i = fromIndex >> 0;
+  if (typeof fromIndex === 'number') {
+    i = fromIndex;
     if (i < 0) {
       i += length;
       if (i < 0) {
@@ -444,8 +444,8 @@ exports.lastIndexOf = function fastLastIndexOf (subject, target, fromIndex) {
   var length = subject.length,
       i = length - 1;
 
-  if (fromIndex !== undefined) {
-    i = fromIndex >> 0;
+  if (typeof fromIndex === 'number') {
+    i = fromIndex;
     if (i < 0) {
       i += length;
     }

--- a/test/test.js
+++ b/test/test.js
@@ -294,34 +294,6 @@ describe('fast.indexOf()', function () {
   it('from index -4', function() {
     fast.indexOf(arr, 3, -4).should.equal(2);
   });
-  // These tests will by proxy be stress testing the toInteger internal private function.
-  it('index NaN becomes 0', function() {
-    fast.indexOf(arr, 1, NaN).should.equal(0);
-  });
-  it('index true becomes 1', function() {
-    fast.indexOf(arr, 1, true).should.equal(-1);
-  });
-  it('index false becomes 0', function() {
-    fast.indexOf(arr, 1, false).should.equal(0);
-  });
-  it('index 0.1 becomes 0', function() {
-    fast.indexOf(arr, 1, 0.1).should.equal(0);
-  });
-  it('index 1.1 becomes 1', function() {
-    fast.indexOf(arr, 1, 1.1).should.equal(-1);
-  });
-  it('index -0.1 becomes 0', function() {
-    fast.indexOf(arr, 3, -0.1).should.equal(2);
-  });
-  it('index -1.1 becomes -1', function() {
-    fast.indexOf(arr, 3, -1.1).should.equal(2);
-  });
-  it('index 1.7 becomes 1', function() {
-    fast.indexOf(arr, 1, 1.7).should.equal(-1);
-  });
-  it('index -1.7 becomes -1', function() {
-    fast.indexOf(arr, 3, -1.7).should.equal(2);
-  });
 });
 
 describe('fast.lastIndexOf()', function () {


### PR DESCRIPTION
The previous code with `fromIndex` support introduced a weird edge case in order to deal with bad input. This PR changes the code to only work with integer values, not booleans, objects, NaNs etc. If the user passes a non numeric value it will be silently ignored.
