### PR TITLE
Add a `Fast` wrapper class

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,40 @@ function Fast (value) {
 
 module.exports = exports = Fast;
 
+
+/**
+ * # Concat
+ *
+ * Concatenate multiple arrays.
+ *
+ * @param  {Array|mixed} item, ... The item(s) to concatenate.
+ * @return {Fast}                  A new Fast object, containing the results.
+ */
+Fast.prototype.concat = function Fast$concat () {
+  var length = this.value.length,
+      arr = new Array(length),
+      i, item, childLength, j;
+
+  for (i = 0; i < length; i++) {
+    arr[i] = this.value[i];
+  }
+
+  length = arguments.length;
+  for (i = 0; i < length; i++) {
+    item = arguments[i];
+    if (Array.isArray(item)) {
+      childLength = item.length;
+      for (j = 0; j < childLength; j++) {
+        arr.push(item[j]);
+      }
+    }
+    else {
+      arr.push(item);
+    }
+  }
+  return new Fast(arr);
+};
+
 /**
  * Fast Map
  *

--- a/test/test.js
+++ b/test/test.js
@@ -653,13 +653,14 @@ describe('Fast', function () {
       })
       .map(function (item) {
         return item / 2;
-      });
+      })
+      .concat(1, [2, 3]);
     });
     it('should perform functions in a chain', function () {
       result.should.be.an.instanceOf(fast);
     });
     it('reduce to a final value', function () {
-      result.reduce(function (a, b) { return a + b; }).should.equal(9);
+      result.reduce(function (a, b) { return a + b; }).should.equal(15);
     });
   });
 });


### PR DESCRIPTION
Provided for convenience, allows `fast` methods to be chained.

``` js
var arr = fast([1,2,3,4,5,6]);
var result = arr.filter(function (item) {
  return item % 2 === 0;
});
result instanceof fast; // true
result.length; // 3
```
