### PR TITLE
fix fast.assign() to align with spec

### DIFF
--- a/bench/assign-10.js
+++ b/bench/assign-10.js
@@ -10,127 +10,127 @@ var fast = require('../lib'),
 exports['Object.assign()' + (shimmed ? ' (shim!)' : '')] = function () {
   return  Object.assign(
     {a: Math.random()},
-    {
+    modObj({
       b: Math.random()
-    },
-    {
+    }),
+    modObj({
       c: Math.random()
-    },
-    {
+    }),
+    modObj({
       d: Math.random(),
       da: Math.random(),
       db: Math.random()
-    },
-    {
+    }),
+    modObj({
       e: Math.random()
-    },
-    {
+    }),
+    modObj({
       f: Math.random(),
       fa: Math.random(),
       fb: Math.random(),
       fc: Math.random()
-    },
-    {
+    }),
+    modObj({
       g: Math.random()
-    },
-    {
+    }),
+    modObj({
       h: Math.random()
-    },
-    {
+    }),
+    modObj({
       i: Math.random(),
       ia: Math.random()
-    },
-    {
+    }),
+    modObj({
       j: Math.random()
-    },
-    {
+    }),
+    modObj({
       k: Math.random()
-    }
+    })
   );
 };
 
 exports['fast.assign()'] = function () {
   return fast.assign(
     {a: Math.random()},
-    {
+    modObj({
       b: Math.random()
-    },
-    {
+    }),
+    modObj({
       c: Math.random()
-    },
-    {
+    }),
+    modObj({
       d: Math.random(),
       da: Math.random(),
       db: Math.random()
-    },
-    {
+    }),
+    modObj({
       e: Math.random()
-    },
-    {
+    }),
+    modObj({
       f: Math.random(),
       fa: Math.random(),
       fb: Math.random(),
       fc: Math.random()
-    },
-    {
+    }),
+    modObj({
       g: Math.random()
-    },
-    {
+    }),
+    modObj({
       h: Math.random()
-    },
-    {
+    }),
+    modObj({
       i: Math.random(),
       ia: Math.random()
-    },
-    {
+    }),
+    modObj({
       j: Math.random()
-    },
-    {
+    }),
+    modObj({
       k: Math.random()
-    }
+    })
   );
 
 };
 
-exports['fast.assign() v0.0.4a'] = function () {
-  return history.assign_0_0_4a(
+exports['fast.assign() v0.0.4c'] = function () {
+  return history.assign_0_0_4c(
     {a: Math.random()},
-    {
+    modObj({
       b: Math.random()
-    },
-    {
+    }),
+    modObj({
       c: Math.random()
-    },
-    {
+    }),
+    modObj({
       d: Math.random(),
       da: Math.random(),
       db: Math.random()
-    },
-    {
+    }),
+    modObj({
       e: Math.random()
-    },
-    {
+    }),
+    modObj({
       f: Math.random(),
       fa: Math.random(),
       fb: Math.random(),
       fc: Math.random()
-    },
-    {
+    }),
+    modObj({
       g: Math.random()
-    },
-    {
+    }),
+    modObj({
       h: Math.random()
-    },
-    {
+    }),
+    modObj({
       i: Math.random(),
       ia: Math.random()
-    },
-    {
+    }),
+    modObj({
       j: Math.random()
-    },
-    {
+    }),
+    modObj({
       k: Math.random()
-    }
+    })
   );
 
 };
@@ -138,85 +138,48 @@ exports['fast.assign() v0.0.4a'] = function () {
 exports['fast.assign() v0.0.4b'] = function () {
   return history.assign_0_0_4b(
     {a: Math.random()},
-    {
+    modObj({
       b: Math.random()
-    },
-    {
+    }),
+    modObj({
       c: Math.random()
-    },
-    {
+    }),
+    modObj({
       d: Math.random(),
       da: Math.random(),
       db: Math.random()
-    },
-    {
+    }),
+    modObj({
       e: Math.random()
-    },
-    {
+    }),
+    modObj({
       f: Math.random(),
       fa: Math.random(),
       fb: Math.random(),
       fc: Math.random()
-    },
-    {
+    }),
+    modObj({
       g: Math.random()
-    },
-    {
+    }),
+    modObj({
       h: Math.random()
-    },
-    {
+    }),
+    modObj({
       i: Math.random(),
       ia: Math.random()
-    },
-    {
+    }),
+    modObj({
       j: Math.random()
-    },
-    {
+    }),
+    modObj({
       k: Math.random()
-    }
+    })
   );
 
 };
 
-exports['underscore.extend()'] = function () {
-  return underscore.extend(
-    {a: Math.random()},
-    {
-      b: Math.random()
-    },
-    {
-      c: Math.random()
-    },
-    {
-      d: Math.random(),
-      da: Math.random(),
-      db: Math.random()
-    },
-    {
-      e: Math.random()
-    },
-    {
-      f: Math.random(),
-      fa: Math.random(),
-      fb: Math.random(),
-      fc: Math.random()
-    },
-    {
-      g: Math.random()
-    },
-    {
-      h: Math.random()
-    },
-    {
-      i: Math.random(),
-      ia: Math.random()
-    },
-    {
-      j: Math.random()
-    },
-    {
-      k: Math.random()
-    }
-  );
 
-};
+function modObj (obj) {
+  obj['wat' + Math.floor(Math.random() * 10000)] = Math.random();
+  return obj;
+}

--- a/bench/assign-3.js
+++ b/bench/assign-3.js
@@ -10,52 +10,52 @@ var fast = require('../lib'),
 exports['Object.assign()' + (shimmed ? ' (shim!)' : '')] = function () {
   return  Object.assign(
     {a: Math.random()},
-    {
+    modObj({
       b: Math.random()
-    },
-    {
+    }),
+    modObj({
       c: Math.random(),
       ca: Math.random(),
       cb: Math.random()
-    },
-    {
+    }),
+    modObj({
       d: Math.random()
-    }
+    })
   );
 };
 
 exports['fast.assign()'] = function () {
   return fast.assign(
     {a: Math.random()},
-    {
+    modObj({
       b: Math.random()
-    },
-    {
+    }),
+    modObj({
       c: Math.random(),
       ca: Math.random(),
       cb: Math.random()
-    },
-    {
+    }),
+    modObj({
       d: Math.random()
-    }
+    })
   );
 
 };
 
-exports['fast.assign() v0.0.4a'] = function () {
-  return history.assign_0_0_4a(
+exports['fast.assign() v0.0.4c'] = function () {
+  return history.assign_0_0_4c(
     {a: Math.random()},
-    {
+    modObj({
       b: Math.random()
-    },
-    {
+    }),
+    modObj({
       c: Math.random(),
       ca: Math.random(),
       cb: Math.random()
-    },
-    {
+    }),
+    modObj({
       d: Math.random()
-    }
+    })
   );
 
 };
@@ -63,35 +63,23 @@ exports['fast.assign() v0.0.4a'] = function () {
 exports['fast.assign() v0.0.4b'] = function () {
   return history.assign_0_0_4b(
     {a: Math.random()},
-    {
+    modObj({
       b: Math.random()
-    },
-    {
+    }),
+    modObj({
       c: Math.random(),
       ca: Math.random(),
       cb: Math.random()
-    },
-    {
+    }),
+    modObj({
       d: Math.random()
-    }
+    })
   );
 
 };
 
-exports['underscore.extend()'] = function () {
-  return underscore.extend(
-    {a: Math.random()},
-    {
-      b: Math.random()
-    },
-    {
-      c: Math.random(),
-      ca: Math.random(),
-      cb: Math.random()
-    },
-    {
-      d: Math.random()
-    }
-  );
 
-};
+function modObj (obj) {
+  obj['wat' + Math.floor(Math.random() * 10000)] = Math.random();
+  return obj;
+}

--- a/bench/assign.js
+++ b/bench/assign.js
@@ -7,83 +7,68 @@ var fast = require('../lib'),
     history = require('../test/history');
 
 exports['Object.assign()' + (shimmed ? ' (shim!)' : '')] = function () {
-  return  Object.assign(
-    {a: Math.random()},
-    {
-      b: Math.random(),
-      c: Math.random(),
-      d: Math.random(),
-      e: Math.random(),
-      f: Math.random()
-    }
-  );
+  return Object.assign({a: Math.random()}, modObj({
+        b: Math.random(),
+        c: Math.random(),
+        d: Math.random(),
+        e: Math.random(),
+        f: Math.random(),
+        g: Math.random(),
+        h: Math.random()
+      }));
 };
 
 exports['fast.assign()'] = function () {
-  return fast.assign(
-    {a: Math.random()},
-    {
-      b: Math.random(),
-      c: Math.random(),
-      d: Math.random(),
-      e: Math.random(),
-      f: Math.random()
-    }
-  );
+  return fast.assign({a: Math.random()}, modObj({
+        b: Math.random(),
+        c: Math.random(),
+        d: Math.random(),
+        e: Math.random(),
+        f: Math.random(),
+        g: Math.random(),
+        h: Math.random()
+      }));
 };
 
-exports['fast.assign() v0.0.4a'] = function () {
-  return history.assign_0_0_4a(
-    {a: Math.random()},
-    {
-      b: Math.random(),
-      c: Math.random(),
-      d: Math.random(),
-      e: Math.random(),
-      f: Math.random()
-    }
-  );
+exports['fast.assign() v0.0.4c'] = function () {
+  return history.assign_0_0_4c({a: Math.random()}, modObj({
+        b: Math.random(),
+        c: Math.random(),
+        d: Math.random(),
+        e: Math.random(),
+        f: Math.random(),
+        g: Math.random(),
+        h: Math.random()
+      }));
 };
 
 exports['fast.assign() v0.0.4b'] = function () {
-  return history.assign_0_0_4b(
-    {a: Math.random()},
-    {
-      b: Math.random(),
-      c: Math.random(),
-      d: Math.random(),
-      e: Math.random(),
-      f: Math.random()
-    }
-  );
-};
-
-
-exports['underscore.extend()'] = function () {
-  return underscore.extend(
-    {a: Math.random()},
-    {
-      b: Math.random(),
-      c: Math.random(),
-      d: Math.random(),
-      e: Math.random(),
-      f: Math.random()
-    }
-  );
+  return history.assign_0_0_4b({a: Math.random()}, modObj({
+        b: Math.random(),
+        c: Math.random(),
+        d: Math.random(),
+        e: Math.random(),
+        f: Math.random(),
+        g: Math.random(),
+        h: Math.random()
+      }));
 };
 
 exports['lodash.assign()'] = function () {
-  return lodash.assign(
-    {a: Math.random()},
-    {
-      b: Math.random(),
-      c: Math.random(),
-      d: Math.random(),
-      e: Math.random(),
-      f: Math.random()
-    }
-  );
+  return lodash.assign({a: Math.random()}, modObj({
+        b: Math.random(),
+        c: Math.random(),
+        d: Math.random(),
+        e: Math.random(),
+        f: Math.random(),
+        g: Math.random(),
+        h: Math.random()
+      }));
 };
 
 
 
+function modObj (obj) {
+  obj['wat' + Math.floor(Math.random() * 10000)] = Math.random();
+  return obj;
+}

--- a/lib/assign.js
+++ b/lib/assign.js
@@ -18,12 +18,15 @@
  * @return {Object}             The updated target object.
  */
 module.exports = function fastAssign (target) {
-  var length = arguments.length,
-      source, key, i;
+  var totalArgs = arguments.length,
+      source, i, totalKeys, keys, key, j;
 
-  for (i = 1; i < length; i++) {
+  for (i = 1; i < totalArgs; i++) {
     source = arguments[i];
-    for (key in source) {
+    keys = Object.keys(source);
+    totalKeys = keys.length;
+    for (j = 0; j < totalKeys; j++) {
+      key = keys[j];
       target[key] = source[key];
     }
   }

--- a/test/history.js
+++ b/test/history.js
@@ -387,3 +387,16 @@ exports.assign_0_0_4b = function fastAssign (target) {
   }
   return target;
 };
+
+exports.assign_0_0_4c = function fastAssign (target) {
+  var totalArgs = arguments.length,
+      source, i;
+
+  for (i = 1; i < totalArgs; i++) {
+    source = arguments[i];
+    for (var key in source) {
+      target[key] = source[key];
+    }
+  }
+  return target;
+};


### PR DESCRIPTION
fixes #63 

I also changed the benchmarks to defeat some of V8's `for..in` optimisations which I think were obscuring the result.

```
  Object.assign() vs fast.assign()
    ✓  Object.assign() (shim!) x 61,570 ops/sec ±1.78% (71 runs sampled)
    ✓  fast.assign() x 72,839 ops/sec ±1.70% (82 runs sampled)
    ✓  fast.assign() v0.0.4c x 71,028 ops/sec ±1.69% (82 runs sampled)
    ✓  fast.assign() v0.0.4b x 64,938 ops/sec ±1.67% (83 runs sampled)
    ✓  lodash.assign() x 69,040 ops/sec ±1.49% (89 runs sampled)

    Result: fast.js is 18.30% faster than Object.assign() (shim!).

  Object.assign() vs fast.assign() (3 arguments)
    ✓  Object.assign() (shim!) x 38,547 ops/sec ±1.28% (85 runs sampled)
    ✓  fast.assign() x 44,037 ops/sec ±1.19% (81 runs sampled)
    ✓  fast.assign() v0.0.4c x 44,914 ops/sec ±1.74% (86 runs sampled)
    ✓  fast.assign() v0.0.4b x 37,553 ops/sec ±1.53% (83 runs sampled)

    Result: fast.js is 14.24% faster than Object.assign() (shim!).

  Object.assign() vs fast.assign() (10 arguments)
    ✓  Object.assign() (shim!) x 16,210 ops/sec ±1.71% (83 runs sampled)
    ✓  fast.assign() x 19,496 ops/sec ±1.69% (81 runs sampled)
    ✓  fast.assign() v0.0.4c x 19,341 ops/sec ±1.97% (81 runs sampled)
    ✓  fast.assign() v0.0.4b x 15,632 ops/sec ±1.91% (82 runs sampled)

    Result: fast.js is 20.27% faster than Object.assign() (shim!).
```
