### PR TITLE
Fix try-fn benchmark

### DIFF
--- a/bench/try-fn.js
+++ b/bench/try-fn.js
@@ -1,46 +1,25 @@
-var fast = require('../'),
-    underscore = require('underscore'),
-    lodash = require('lodash');
+var fast = require('../');
 
-function factorial(op) {
-  // Lanczos Approximation of the Gamma Function
-  // As described in Numerical Recipes in C (2nd ed. Cambridge University Press, 1992)
-  var z = op + 1;
-  var p = [1.000000000190015, 76.18009172947146, -86.50532032941677, 24.01409824083091, -1.231739572450155, 1.208650973866179E-3, -5.395239384953E-6];
-
-  var d1 = Math.sqrt(2 * Math.PI) / z;
-  var d2 = p[0];
-
-  for (var i = 1; i <= 6; ++i) {
-    d2 += p[i] / (z + i);
+function foo(val) {
+  if (val > 0) {
+    return val;
   }
-
-  var d3 = Math.pow((z + 5.5), (z + 0.5));
-  var d4 = Math.exp(-(z + 5.5));
-
-  d = d1 * d2 * d3 * d4;
-
-  return d;
+  
+  throw Error(val);
 }
-
 
 exports['try...catch'] = function () {
   try {
-    return doSomeWork();
-  }
-  catch (e) {
+    return foo(0) + foo(-1);
+  } catch (e) {
     return e;
   }
 }
 
 exports['fast.try()'] = function () {
-  return fast.try(doSomeWork);
+  return fast.try(function () {
+    return foo(0) + foo(-1);
+  }, function (e) {
+    return e;
+  });
 };
-
-
-function doSomeWork () {
-  var d = 0;
-  d += factorial(10 * Math.random());
-  d += factorial(2 * Math.random());
-  return d;
-}


### PR DESCRIPTION
Benchmark should test try-catch instead of math operations.
Using this benchmark I've got different results:
```
$ node --version
v7.2.0
```
```
  Native try {} catch (e) {} vs fast.try() (single function call)
    ✓  try...catch x 218,162 ops/sec ±0.77% (94 runs sampled)
    ✓  fast.try() x 219,740 ops/sec ±0.72% (96 runs sampled)

    Result: fast.js is 0.72% faster than try...catch.
```
```
  Native try {} catch (e) {} vs fast.try() (single function call)
    ✓  try...catch x 211,895 ops/sec ±3.50% (84 runs sampled)
    ✓  fast.try() x 191,432 ops/sec ±3.50% (85 runs sampled)

    Result: fast.js is 9.66% slower than try...catch.
```

I guess this means, you shouldn't always use `fast.try` if try-catch statements already split into small functions.